### PR TITLE
Add support for snake_case field keys

### DIFF
--- a/example/lib/person.dart
+++ b/example/lib/person.dart
@@ -16,3 +16,20 @@ class Person {
     required this.age,
   });
 }
+
+@GenerateFieldKeys(useSnakeCase: true)
+class PersonSnakeCase {
+  final String firstName;
+  final String lastName;
+  final int age;
+  final String aLongFieldName;
+
+  String get fullName => '$firstName $lastName';
+
+  PersonSnakeCase({
+    required this.firstName,
+    required this.lastName,
+    required this.age,
+    required this.aLongFieldName,
+  });
+}

--- a/example/lib/person.g.dart
+++ b/example/lib/person.g.dart
@@ -11,3 +11,11 @@ class $PersonFieldKeys {
   static const String lastName = 'lastName';
   static const String age = 'age';
 }
+
+class $PersonSnakeCaseFieldKeys {
+  static const String firstName = 'first_name';
+  static const String lastName = 'last_name';
+  static const String age = 'age';
+  static const String aLongFieldName = 'a_long_field_name';
+  static const String fullName = 'full_name';
+}

--- a/lib/src/annotations.dart
+++ b/lib/src/annotations.dart
@@ -41,6 +41,7 @@ class GenerateFieldKeys {
   const GenerateFieldKeys({
     this.include = const [],
     this.exclude = const [],
+    this.useSnakeCase = false,
   });
 
   /// The fields to include in the generated class.
@@ -48,4 +49,7 @@ class GenerateFieldKeys {
 
   /// The fields to exclude from the generated class..
   final List<String> exclude;
+
+  /// Whether to use snake_case for the generated field keys.
+  final bool useSnakeCase;
 }

--- a/lib/src/generator.dart
+++ b/lib/src/generator.dart
@@ -35,6 +35,8 @@ class FieldKeysGenerator extends GeneratorForAnnotation<GenerateFieldKeys> {
     final List<String> exclude =
         convertToStringList(annotation.read('exclude'));
 
+    final bool useSnakeCase = annotation.read('useSnakeCase').boolValue;
+
     if (include.isNotEmpty && exclude.isNotEmpty) {
       throw InvalidGenerationSourceError(
         'Cannot specify both `include` and `exclude` on $GenerateFieldKeys annotation.',
@@ -74,7 +76,12 @@ class FieldKeysGenerator extends GeneratorForAnnotation<GenerateFieldKeys> {
         continue;
       }
 
-      buffer.writeln('  static const String $fieldName = \'$fieldName\';');
+      if (useSnakeCase) {
+        buffer.writeln(
+            '  static const String $fieldName = \'${fieldName.replaceAll(RegExp(r'(?<=[a-z])(?=[A-Z])'), '_').toLowerCase()}\';');
+      } else {
+        buffer.writeln('  static const String $fieldName = \'$fieldName\';');
+      }
     }
 
     buffer.writeln('}');


### PR DESCRIPTION
Introduce an option to generate field keys in snake_case format, enhancing flexibility in key naming conventions. 